### PR TITLE
fix-buefy.sass修正

### DIFF
--- a/src/styles/_fix-buefy.sass
+++ b/src/styles/_fix-buefy.sass
@@ -46,3 +46,8 @@
     width: 100%
     margin-left: 0
     text-align: right
+
+.section
+    &.is-full
+        padding-right: 0
+        padding-left: 0


### PR DESCRIPTION
* section.is-fullのpadding-right,padding-leftに0を指定